### PR TITLE
Fix DisplayAutoDespawnWatcher for Folia

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -902,12 +902,11 @@ public class QuickShop implements QuickShopAPI, Reloadable {
 
     if(this.display && getConfig().getBoolean("shop.display-auto-despawn")) {
       this.displayAutoDespawnWatcher = new DisplayAutoDespawnWatcher(this);
-      //BUKKIT METHOD SHOULD ALWAYS EXECUTE ON THE SERVER MAIN THEAD
-      this.displayAutoDespawnWatcher.runTaskTimer(javaPlugin, 20, getConfig().getInt("shop.display-check-time")); // not worth async
+      this.displayAutoDespawnWatcher.start(20, getConfig().getInt("shop.display-check-time"));
       logger.warn("Unrecommended use of display-auto-despawn. This feature may have a heavy impact on the server's performance!");
     } else {
       if(this.displayAutoDespawnWatcher != null) {
-        this.displayAutoDespawnWatcher.cancel();
+        this.displayAutoDespawnWatcher.stop();
         this.displayAutoDespawnWatcher = null;
       }
     }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/watcher/DisplayAutoDespawnWatcher.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/watcher/DisplayAutoDespawnWatcher.java
@@ -12,15 +12,16 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.StringJoiner;
 
-public class DisplayAutoDespawnWatcher extends BukkitRunnable implements Reloadable, SubPasteItem {
+public class DisplayAutoDespawnWatcher implements Runnable, Reloadable, SubPasteItem {
 
   private final QuickShop plugin;
   private int range;
+  private WrappedTask task;
 
   public DisplayAutoDespawnWatcher(@NotNull final QuickShop plugin) {
 
@@ -82,10 +83,17 @@ public class DisplayAutoDespawnWatcher extends BukkitRunnable implements Reloada
     }
   }
 
-  @Override
-  public synchronized void cancel() throws IllegalStateException {
+  public void start(final int delay, final int period) {
+    task = QuickShop.folia().getScheduler().runTimer(this, delay, period);
+  }
 
-    super.cancel();
+  public void stop() {
+    try {
+      if(task != null && !task.isCancelled()) {
+        task.cancel();
+      }
+    } catch(final IllegalStateException ignored) {
+    }
     plugin.getReloadManager().unregister(this);
     plugin.getPasteManager().unregister(plugin.getJavaPlugin(), this);
   }


### PR DESCRIPTION
## Summary
- switch `DisplayAutoDespawnWatcher` to use FoliaLib's scheduler instead of BukkitRunnable
- update `QuickShop` registration logic to call the new watcher API

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686404dc0188833292fab4a7786de540